### PR TITLE
Interact with enter and exit keyboard strokes in text field input (not text area)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ onSave|function|Yes||Function will be called when save button clicked. `value` i
 inputProps|object|No||Props to be passed to input element. Any kind of valid DOM attributes are welcome.
 viewProps|object|No||Props to be passed to div element that shows the text. You can specify your own `styles` or `className`
 validation|function|No||Pass your own validation function. takes one param -> `value`. It must return `true` or `false`
-validationMessage|string|No|Invalid Value| If validation fails this message will appear
+validationMessage|node|No|Invalid Value| If validation fails this message will appear
 onValidationFail|function|No||Pass your own function to track when validation failed. See Examples page for the usage.
 onCancel|function|No||Function will be called when editing is cancelled.
 saveButtonContent|node|No|`''`|Content for save button. Any valid element is allowed. Default is: &#10003;

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare module 'react-editext' {
         /**
         If validation fails this message will appear
         */
-        validationMessage?: string;
+        validationMessage?: any;
         /** Pass your own validation function.
         * takes one param -> `value`.
         * It must return `true` or `false`

--- a/src/index.js
+++ b/src/index.js
@@ -234,7 +234,7 @@ EdiText.propTypes = {
   viewProps: PropTypes.object,
   value: PropTypes.string.isRequired,
   hint: PropTypes.node,
-  validationMessage: PropTypes.string,
+  validationMessage: PropTypes.node,
   validation: PropTypes.func,
   onValidationFail: PropTypes.func,
   type: PropTypes.oneOf([

--- a/src/index.js
+++ b/src/index.js
@@ -26,17 +26,6 @@ export default class EdiText extends Component {
     }
   }
 
-  _onInputKeyDown = e => {
-    const enterKeyCode = 13;
-    const escapeKeyCode = 27;
-    if (e.keyCode === enterKeyCode) {
-      this._onSave();
-    }
-    if (e.keyCode === escapeKeyCode) {
-      this._onCancel();
-    }
-  }
-
   _onInputChange = e => {
     this.setState({
       valid: true,
@@ -98,7 +87,6 @@ export default class EdiText extends Component {
           {...this.props.inputProps}
           value={this.state.value}
           type={this.props.type}
-          onKeyDown={this._onInputKeyDown}
           onChange={this._onInputChange}
           autoFocus={this.state.editing}
         />

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,17 @@ export default class EdiText extends Component {
     }
   }
 
+  _onInputKeyDown = e => {
+    const enterKeyCode = 13;
+    const escapeKeyCode = 27;
+    if (e.keyCode === enterKeyCode) {
+      this._onSave();
+    }
+    if (e.keyCode === escapeKeyCode) {
+      this._onCancel();
+    }
+  }
+
   _onInputChange = e => {
     this.setState({
       valid: true,
@@ -87,6 +98,7 @@ export default class EdiText extends Component {
           {...this.props.inputProps}
           value={this.state.value}
           type={this.props.type}
+          onKeyDown={this._onInputKeyDown}
           onChange={this._onInputChange}
           autoFocus={this.state.editing}
         />


### PR DESCRIPTION
Hey,

I have added the feature that when the user presses enter while he is editing the text input, then his changes gets saved. And that when he presses escape while he is editing, then his changes get discarded.

I have also myself been using the validationMessage as a node, i tested it and it works perfectly fine, so i thought it is better to change the propType of validationMessage to be node, this also makes the component more feature rich, and it already supports validationMessage to be node.

And Thanks for the great component 


