### PR TITLE
feat: pass inputProps to event listener props

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ You can customize almost everything based on your needs. Please navigate to [Pro
 value|string|Yes|`''`|Value of the content and input [in edit mode]
 type|string|Yes|text|Input type. Possible options are: `text`, `password`, `number`, `email`, `textarea`, `date`, `datetime-local`, `time`, `month`, `url`, `week`, `tel`
 hint|node|No|`''`|A simple hint message appears at the bottom of input element. Any valid element is allowed.
-onSave|function|Yes||Function will be called when save button clicked. `value` is passed to cb.
+onSave|function|Yes||Function will be called when save button clicked. `value` and `inputProps` are passed to cb.
 inputProps|object|No||Props to be passed to input element. Any kind of valid DOM attributes are welcome.
 viewProps|object|No||Props to be passed to div element that shows the text. You can specify your own `styles` or `className`
 validation|function|No||Pass your own validation function. takes one param -> `value`. It must return `true` or `false`
 validationMessage|node|No|Invalid Value| If validation fails this message will appear
 onValidationFail|function|No||Pass your own function to track when validation failed. See Examples page for the usage.
-onCancel|function|No||Function will be called when editing is cancelled.
+onCancel|function|No||Function will be called when editing is cancelled. `value` and `inputProps` are passed as params.
 saveButtonContent|node|No|`''`|Content for save button. Any valid element is allowed. Default is: &#10003;
 cancelButtonContent|node|No|`''`|Content for cancel button. Any valid element is allowed. Default is: &#10005;
 editButtonContent|node|No|`''`|Content for edit button. Any valid element is allowed. Default is: &#9998;

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -41,8 +41,9 @@ const StyledEdiText = styled(EdiText)`
 export default class App extends Component {
   state = { editing: false, logs: [] }
 
-  handleSave = val => {
+  handleSave = (val, inputProps) => {
     console.log('Edited Value -> ', val)
+    console.log('Edited input props -> ', inputProps)
   }
 
   handleValidationFail = textValue => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,13 +46,16 @@ declare module 'react-editext' {
         type: EdiTextType;
         /**
          * will be called when user clicked cancel button
+         * @param value the current value of input when cancelled.
+         * @param inputProps inputProps that passed to the element.
         */
-        onCancel?: (...args: any[]) => any;
+        onCancel?: (value: any, inputProps: React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>) => any;
         /**
          * will be called when user clicked save button.
-         * takes one param <value> which is the current value of input
+         * @param value the current value of input
+         * @param inputProps inputProps that passed to the element.
         */
-        onSave: (...args: string[]) => any;
+        onSave: (value: any, inputProps: React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>) => any;
         /**
          * Custom class name for SAVE button.
          * */
@@ -107,9 +110,10 @@ declare module 'react-editext' {
         /**
          * Will be called when the editing mode is active.
          *
-         * `value` is the value of the input at the time when editing started.
+         * @param value the value of the input at the time when editing started.
+         * @param inputProps inputProps that passed to the element.
          */
-        onEditingStart?: (value:string) => any;
+        onEditingStart?: (value: any, inputProps: React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> ) => any;
         /**
          * Set it to `true` if you want to display action buttons **only**
          * when the text hovered by the user.

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ export default class EdiText extends Component {
         editing: false,
         value: this.state.savedValue || this.props.value
       },
-      () => this.props.onCancel(this.state.value)
+      () => this.props.onCancel(this.state.value, this.props.inputProps)
     )
   }
 
@@ -108,7 +108,7 @@ export default class EdiText extends Component {
   }
 
   handleSave = () => {
-    const { onSave, validation, onValidationFail } = this.props
+    const { onSave, validation, onValidationFail, inputProps } = this.props
     const isValid = validation(this.state.value)
     if (!isValid) {
       return this.setState({ valid: false }, () => {
@@ -120,7 +120,7 @@ export default class EdiText extends Component {
         editing: false,
         savedValue: this.state.value
       },
-      () => onSave(this.state.savedValue)
+      () => onSave(this.state.savedValue, inputProps)
     )
   }
 


### PR DESCRIPTION
Now `inputProps` is available as a second prop for `onSave`, `onCancel` and `onEditingStart` callbacks. You can see distinguish multiple Editexts from each other by using `inputProps`

closes #57 